### PR TITLE
Include loader.js first in vendor-static

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,11 @@ module.exports = {
       emberDebugPath = `${app.bowerDirectory}/ember/ember.debug.js`;
     }
 
+    app.import('vendor/loader/loader.js', {
+      outputFile: vendorStaticFilepath,
+      prepend: true
+    });
+
     app.import(`vendor/${vendorStaticPrefixPath}`, {
       outputFile: vendorStaticFilepath
     });
@@ -81,20 +86,19 @@ module.exports = {
 
 module.exports.removeOutputFiles = removeOutputFiles;
 function removeOutputFiles(app, useSource, emberSource) {
-  // TODO: public API for ember-cli? maybe: https://github.com/ember-cli/ember-cli/pull/7060
-  let filesToRemove;
+  let filesToRemove = [ 'vendor/loader/loader.js'];
   if (useSource) {
-    filesToRemove = [
+    filesToRemove.push(
       emberSource.paths.jquery,
       emberSource.paths.prod,
       emberSource.paths.debug
-    ];
+    );
   } else {
-    filesToRemove = [
+    filesToRemove.push(
       `${app.bowerDirectory}/jquery/dist/jquery.js`,
       `${app.bowerDirectory}/ember/ember.prod.js`,
       `${app.bowerDirectory}/ember/ember.debug.js`
-    ];
+    );
   }
 
   for (let i = 0; i < filesToRemove.length; i++) {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,10 @@
     "node": ">= 10.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": [
+      "loader.js"
+    ]
   },
   "dependencies": {
     "broccoli-file-creator": "^2.1.1",


### PR DESCRIPTION
There are two module registries used by Ember:

- an internal registry with special handling of Ember-specific assets, which in pre-Ember 3.27 was used for Ember-internal modules via the `Ember.__loader`
- the regular `define`/`require` registry

As of 3.27+, Ember attempts to use the latter and only falls back to the Ember-specific if it is missing, but this means that if `loader.js` has not yet loaded (as in the case of the `vendor-static.js` file generated via this addon), modules can get registered into the separate registries and therefore not be resolveable at runtime. Pushing `loader.js` itself into `vendor-static.js`, and making sure that `ember-vendor-split` runs after `loader.js` does in Ember's build pipeline, works around this by guaranteeing that it sets up the primary/ambient registry before Ember's own special sauce happens.

(In the future, after full Embroider adoption, all of this will become completely unnecessary because there will be much better tools for defining bundles such that caching will work as we want.)

---

I have been running LinkedIn's app and test suite against `ember-source@3.28.0` with this change for the last week and change, and it has worked as expected so far. 😅 